### PR TITLE
Avoid logging DATABASE_URL (CWE-532: Sensitive Information in Logs)

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -28,7 +28,8 @@ const resourceBaseUrl = new URL(databaseUrl);
 resourceBaseUrl.protocol = "postgres:";
 resourceBaseUrl.password = "";
 
-process.stderr.write("starting server. url: " + databaseUrl + "\n");
+process.stderr.write("starting server\n");
+
 const pool = new pg.Pool({
   connectionString: databaseUrl,
 });


### PR DESCRIPTION
Removes printing of the full `DATABASE_URL` at startup and replaces it with a neutral starting server message to prevent credential leakage in logs. No functional changes to connectivity or behavior.