### PR TITLE
ensure that the updated Server API contract is satisfied

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -13,10 +13,20 @@ import {
   CompleteRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 
-const server = new Server({
-  name: "postgres-context-server",
-  version: "0.1.0",
-});
+const server = new Server(
+  {
+    name: "postgres-context-server",
+    version: "0.1.0",
+  },
+  {
+    capabilities: {
+      resources: {},
+      tools: {},
+      prompts: {},
+      completions: {},
+    },
+  },
+);
 
 const databaseUrl = process.env.DATABASE_URL;
 if (typeof databaseUrl == null || databaseUrl.trim().length === 0) {


### PR DESCRIPTION
It looks like the API contract for `Server` was updated when we bumped the `@modelcontextprotocol/sdk` version. This PR adds the required configuration, and I did basic testing using `npx @modelcontextprotocol/inspector` to validate that the MCP server now works again.

/cc @ConradIrwin 